### PR TITLE
wazo-reset: reinstall removed packages

### DIFF
--- a/sbin/wazo-reset
+++ b/sbin/wazo-reset
@@ -83,6 +83,9 @@ wazo-auth-keys service update --recreate
 echo 'Cleaning up wazo-provd configs and devices...'
 rm -rf /var/lib/wazo-provd/jsondb/*
 
+echo 'Restoring removed packages...'
+apt-get install -y wazo-nestbox-plugin wazo-deployd-client
+
 trap ERR
 wazo-service restart
 systemctl start wazo-setupd


### PR DESCRIPTION
Why:

* When wazo-setupd receives POST /setup, it may remove some packages.
When running wazo-reset, we expect the platform to return to its
original state, including needed packages.