### PR TITLE
restart setupd instead of only start it

### DIFF
--- a/sbin/wazo-reset
+++ b/sbin/wazo-reset
@@ -87,6 +87,6 @@ rm -rf /var/lib/wazo-provd/jsondb/*
 
 trap ERR
 wazo-service restart
-systemctl start wazo-setupd
+systemctl restart wazo-setupd
 
 echo 'Wazo reset successful.'


### PR DESCRIPTION
why: if you use wazo-reset before calling wazo-setupd, then the
service will never be restarted. But the credential loaded in its config
file won't be the same. Then it could not create a service token